### PR TITLE
Added note on location of warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default function attacher(opts = {}) {
     if (!deprecationWarningIssued) {
       deprecationWarningIssued = true
       console.warn(
-        'Deprecation Warning: `behaviour` is a nonstandard option. Use `behavior` instead.'
+        '[remark-autolink-headings] Deprecation Warning: `behaviour` is a nonstandard option. Use `behavior` instead.'
       )
     }
 


### PR DESCRIPTION
When remark is used as a dependency of a dependency it is a bit tricky to figure out where the deprecation warning comes from. This PR adds a mention on the module causing the deprecation warning.