### PR TITLE
Usage description for next.js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@
 npm install remark-autolink-headings
 ```
 
-## Use
+## Use - Unified
 
 Say we have the following markdown file, `example.md`:
 
@@ -66,6 +66,18 @@ Now, running `node example` yields:
 <h4 id="elit"><a href="#elit" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>elit</h4>
 <h5 id="elit-1"><a href="#elit-1" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>elit</h5>
 ```
+
+## Use - Next.js
+
+Configure remark MDX plugins inside `next.config.js`.  Autolink Headings requires `remark-slug` to be installed.
+
+```
+module.exports = withMdx({
+  remarkPlugins: [
+    require("remark-autolink-headings"),
+    require("remark-slug"),
+  ],
+ ```
 
 ## API
 


### PR DESCRIPTION
Add a usage section to the readme, targeted for users of Nextjs+MDX. Explains the dependency on `react-slug`

My apologies if you find this inappropriate for this library, because I know it is meant for use with unified. I just think it will save folks some time because this plugin is very popular in next apps, and I was confused for days when it did not work without `remark-slug`!

As an alternative, maybe add an error message in the case where remark-slug is not installed? Currently this plugin is silently broken without it.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
